### PR TITLE
fix: Generate unique app ID to allow saving dishes

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,21 @@
         </div>
     </div>
 
+    <script>
+        (function() {
+            let appId = localStorage.getItem('dishDashAppId');
+            if (!appId) {
+                // Basic UUID generator
+                appId = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+                    var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+                    return v.toString(16);
+                });
+                localStorage.setItem('dishDashAppId', appId);
+            }
+            window.__app_id = appId;
+            console.log('Dish Dash App ID:', window.__app_id);
+        })();
+    </script>
     <script type="module">
         // Firebase Imports
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";


### PR DESCRIPTION
The application was failing to save dishes to Firestore because it was using a default, non-functional `appId` of 'default-app-id'. The Firestore path for dishes is structured as `artifacts/{appId}/users/{userId}/dishes`, and the security rules require a unique `appId`.

This change introduces a script that runs before the main application logic. The script checks for an `appId` in `localStorage`. If one is not found, it generates a new UUID, saves it to `localStorage` for persistence across sessions, and then assigns it to the global `window.__app_id` variable.

This ensures that the application uses a valid and unique `appId` when constructing the Firestore path, which resolves the "Failed to save dish" error and allows users to save their data correctly.