### PR TITLE
feat: Update menu filtering and sorting logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,18 +388,27 @@
         }
 
         function filterAndRenderMenuDishes() {
-            let filteredDishes = dishes;
+            let filteredDishes = [];
             if (selectedMenuFilters.length > 0) {
-                filteredDishes = dishes.filter(dish => {
+                filteredDishes = dishes.map(dish => {
                     const dishIngredients = [...dish.protein, ...dish.side, ...dish.veggie];
-                    return selectedMenuFilters.every(filter => dishIngredients.includes(filter));
-                });
+                    const matchCount = selectedMenuFilters.filter(filter => dishIngredients.includes(filter)).length;
+                    return { ...dish, matchCount };
+                }).filter(dish => dish.matchCount > 0);
+
+                // Sort by match count descending
+                filteredDishes.sort((a, b) => b.matchCount - a.matchCount);
             }
+
             menuDishesListContainer.innerHTML = '';
             dishCount.textContent = `${filteredDishes.length} of ${dishes.length} dishes shown`;
 
             if (filteredDishes.length === 0) {
-                menuDishesListContainer.innerHTML = `<p class="text-gray-400">No dishes match your selected ingredients.</p>`;
+                if (selectedMenuFilters.length > 0) {
+                    menuDishesListContainer.innerHTML = `<p class="text-gray-400">No dishes match your selected ingredients.</p>`;
+                } else {
+                    menuDishesListContainer.innerHTML = `<p class="text-gray-400">Select ingredients to see what you can cook.</p>`;
+                }
                 return;
             }
             


### PR DESCRIPTION
The "You can Cook" section on the Menu page now displays dishes that contain at least one of the selected ingredients.

- Dishes are sorted by the number of matching ingredients in descending order.
- By default, no dishes are shown if no ingredients are selected.
- The filtering logic was changed from `every` to `some` to allow for partial matches.